### PR TITLE
Content dual view

### DIFF
--- a/entrypoints/content/components/enhancers/ContentEnhancer.tsx
+++ b/entrypoints/content/components/enhancers/ContentEnhancer.tsx
@@ -134,6 +134,9 @@ const handleNumberKeyPress = (e: KeyEventData): void => {
   }
 };
 
+const DUAL_VIEW_STORAGE_KEY = "mikoto-dual-view";
+const DUAL_VIEW_CLASS = "mikoto-dual-view-enabled";
+
 export const ContentEnhancer: React.FC = () => {
   const handleContentItems = useCallback(() => {
     const main = findContentWrapper();
@@ -146,6 +149,38 @@ export const ContentEnhancer: React.FC = () => {
   }, []);
 
   useElementObserver(CONTENT_WRAPPER_LI_SELECTOR, handleContentItems);
+
+  // dual-view設定の適用
+  useEffect(() => {
+    const applyDualView = async () => {
+      const enabled = await storage.getItem<boolean>(
+        `local:${DUAL_VIEW_STORAGE_KEY}`,
+      );
+      if (enabled) {
+        document.body.classList.add(DUAL_VIEW_CLASS);
+      } else {
+        document.body.classList.remove(DUAL_VIEW_CLASS);
+      }
+    };
+
+    applyDualView();
+
+    // 設定変更の監視
+    const unwatch = storage.watch<boolean>(
+      `local:${DUAL_VIEW_STORAGE_KEY}`,
+      (enabled) => {
+        if (enabled) {
+          document.body.classList.add(DUAL_VIEW_CLASS);
+        } else {
+          document.body.classList.remove(DUAL_VIEW_CLASS);
+        }
+      },
+    );
+
+    return () => {
+      unwatch();
+    };
+  }, []);
 
   useEffect(() => {
     const keydownHandler = (e: KeyboardEvent): void => {

--- a/entrypoints/content/components/enhancers/ContentEnhancer.tsx
+++ b/entrypoints/content/components/enhancers/ContentEnhancer.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useEffect } from "react";
+import { createRoot } from "react-dom/client";
 
 import { useElementObserver } from "../../hooks";
 import { CONFIG, applyStyles, containsKeywords } from "../../utils";
+import { DualViewToggle } from "../ui";
 
 const CONTENT_WRAPPER_SELECTOR = ".content-wrapper";
 const CONTENT_WRAPPER_LI_SELECTOR = ".content-wrapper li";
@@ -137,6 +139,27 @@ const handleNumberKeyPress = (e: KeyEventData): void => {
 const DUAL_VIEW_STORAGE_KEY = "mikoto-dual-view";
 const DUAL_VIEW_CLASS = "mikoto-dual-view-enabled";
 
+const insertDualViewToggle = () => {
+  const content = document.querySelector(".content");
+  if (!content) return;
+
+  const clearfix = content.querySelector(".clearfix");
+  if (!clearfix) return;
+
+  const pullRight = clearfix.querySelector(".pull-right");
+  if (!pullRight) return;
+
+  // 既存のトグルボタンを削除
+  const existingToggle = pullRight.querySelector(".mikoto-dual-view-toggle");
+  if (existingToggle) return;
+
+  const container = document.createElement("span");
+  pullRight.appendChild(container);
+
+  const root = createRoot(container);
+  root.render(React.createElement(DualViewToggle));
+};
+
 export const ContentEnhancer: React.FC = () => {
   const handleContentItems = useCallback(() => {
     const main = findContentWrapper();
@@ -164,6 +187,7 @@ export const ContentEnhancer: React.FC = () => {
     };
 
     applyDualView();
+    insertDualViewToggle();
 
     // 設定変更の監視
     const unwatch = storage.watch<boolean>(

--- a/entrypoints/content/components/enhancers/ContentEnhancer.tsx
+++ b/entrypoints/content/components/enhancers/ContentEnhancer.tsx
@@ -143,6 +143,10 @@ const insertDualViewToggle = () => {
   const content = document.querySelector(".content");
   if (!content) return;
 
+  // .problem-containerが存在しない場合は表示しない
+  const problemContainer = content.querySelector(".problem-container");
+  if (!problemContainer) return;
+
   const clearfix = content.querySelector(".clearfix");
   if (!clearfix) return;
 

--- a/entrypoints/content/components/ui/DualViewToggle.tsx
+++ b/entrypoints/content/components/ui/DualViewToggle.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from "react";
+
+const DUAL_VIEW_STORAGE_KEY = "mikoto-dual-view";
+
+export const DualViewToggle: React.FC = () => {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const loadState = async () => {
+      const state = await storage.getItem<boolean>(
+        `local:${DUAL_VIEW_STORAGE_KEY}`,
+      );
+      setEnabled(state || false);
+    };
+
+    loadState();
+
+    const unwatch = storage.watch<boolean>(
+      `local:${DUAL_VIEW_STORAGE_KEY}`,
+      (newState) => {
+        setEnabled(newState || false);
+      },
+    );
+
+    return () => {
+      unwatch();
+    };
+  }, []);
+
+  const handleToggle = async () => {
+    const newEnabled = !enabled;
+    await storage.setItem(`local:${DUAL_VIEW_STORAGE_KEY}`, newEnabled);
+    setEnabled(newEnabled);
+  };
+
+  return (
+    <button
+      className={`btn ${enabled ? "btn-warning" : "btn-default"} mikoto-dual-view-toggle`}
+      onClick={handleToggle}
+      style={{ marginLeft: "10px" }}
+    >
+      <i className={enabled ? "fa fa-columns" : "fa fa-file-text-o"} /> Dual
+      View
+    </button>
+  );
+};

--- a/entrypoints/content/components/ui/index.ts
+++ b/entrypoints/content/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { CharacterCounter } from "./CharacterCounter";
 export { TimeDashboard } from "./TimeDashboard";
+export { DualViewToggle } from "./DualViewToggle";

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -10,6 +10,7 @@ const TARGET_URL_PATTERNS = [
   "https://docs.google.com/presentation/*",
 ];
 const THEME_STORAGE_KEY = "mikoto-theme";
+const DUAL_VIEW_STORAGE_KEY = "mikoto-dual-view";
 
 export type Theme = "light" | "dark";
 

--- a/entrypoints/content/style.css
+++ b/entrypoints/content/style.css
@@ -129,6 +129,31 @@ body {
   }
 }
 
+/* スライド+課題 Dual Viewの横並びレイアウト */
+body.mikoto-dual-view-enabled {
+  .content {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+  }
+
+  .content > .pad-block {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .content > .pad-block:nth-of-type(2) {
+    margin-bottom: 0;
+    max-height: 62vh;
+    overflow: auto;
+  }
+
+  .content > *:not(.pad-block) {
+    flex-basis: 100%;
+  }
+}
+
 /* ダークテーマ */
 body.mikoto-dark-theme {
   background-color: #1a1a1a;

--- a/entrypoints/popup/App.css
+++ b/entrypoints/popup/App.css
@@ -1,42 +1,44 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.popup-container {
+  width: 300px;
+  padding: 20px;
+  font-family: system-ui, -apple-system, sans-serif;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #54bc4ae0);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.popup-container h1 {
+  font-size: 18px;
+  margin: 0 0 20px 0;
+  color: #333;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+  transition: background-color 0.2s;
 }
 
-.card {
-  padding: 2em;
+.setting-item:hover {
+  background-color: #f0f0f0;
 }
 
-.read-the-docs {
-  color: #888;
+.setting-item label {
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+}
+
+.setting-item input[type="checkbox"] {
+  width: 40px;
+  height: 20px;
+  cursor: pointer;
 }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,34 +1,63 @@
-import { useState } from "react";
-import reactLogo from "@/assets/react.svg";
-import wxtLogo from "/wxt.svg";
+import { useEffect, useState } from "react";
 import "./App.css";
 
+const DUAL_VIEW_STORAGE_KEY = "mikoto-dual-view";
+const THEME_STORAGE_KEY = "mikoto-theme";
+
 function App() {
-  const [count, setCount] = useState(0);
+  const [dualViewEnabled, setDualViewEnabled] = useState(false);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      const dualView = await storage.getItem<boolean>(
+        `local:${DUAL_VIEW_STORAGE_KEY}`,
+      );
+      const currentTheme = await storage.getItem<"light" | "dark">(
+        `local:${THEME_STORAGE_KEY}`,
+      );
+      setDualViewEnabled(dualView || false);
+      setTheme(currentTheme || "light");
+    };
+    loadSettings();
+  }, []);
+
+  const handleDualViewToggle = async () => {
+    const newValue = !dualViewEnabled;
+    setDualViewEnabled(newValue);
+    await storage.setItem(`local:${DUAL_VIEW_STORAGE_KEY}`, newValue);
+  };
+
+  const handleThemeToggle = async () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    await storage.setItem(`local:${THEME_STORAGE_KEY}`, newTheme);
+  };
 
   return (
-    <>
-      <div>
-        <a href="https://wxt.dev" target="_blank">
-          <img src={wxtLogo} className="logo" alt="WXT logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="popup-container">
+      <h1>Mikoto (MOOCs #)</h1>
+      <div className="settings">
+        <div className="setting-item">
+          <label htmlFor="dual-view-toggle">スライド横並び表示</label>
+          <input
+            id="dual-view-toggle"
+            type="checkbox"
+            checked={dualViewEnabled}
+            onChange={handleDualViewToggle}
+          />
+        </div>
+        <div className="setting-item">
+          <label htmlFor="theme-toggle">ダークテーマ</label>
+          <input
+            id="theme-toggle"
+            type="checkbox"
+            checked={theme === "dark"}
+            onChange={handleThemeToggle}
+          />
+        </div>
       </div>
-      <h1>WXT + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the WXT and React logos to learn more
-      </p>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
#23
This pull request introduces a new "Dual View" (横並び表示) feature that allows users to display slides and problem content side-by-side, along with UI and settings enhancements for both the content and popup interfaces. The main changes include the implementation of the dual view toggle, persistent user settings via storage, and corresponding style adjustments.

**Dual View Feature Implementation:**

* Added a `DualViewToggle` React component (`DualViewToggle.tsx`) that allows users to enable or disable the dual view layout, with state synchronized to persistent storage.
* Integrated the dual view toggle button into the content UI by inserting it next to existing controls, and ensured only one instance is present at a time (`ContentEnhancer.tsx`). [[1]](diffhunk://#diff-32d80171c0809cfb5994b90b5b5974152e446688f303da00b11a7476efb46d01R2-R6) [[2]](diffhunk://#diff-32d80171c0809cfb5994b90b5b5974152e446688f303da00b11a7476efb46d01R139-R166)
* Applied or removed the dual view layout by toggling a CSS class on the `body` element based on the stored setting, and set up a watcher for real-time updates (`ContentEnhancer.tsx`).

**Styling and Layout Adjustments:**

* Added CSS rules for the dual view layout, ensuring slides and problems are displayed side-by-side when enabled (`style.css`).

**Settings Popup Enhancements:**

* Redesigned the popup interface to include toggles for both dual view and dark theme settings, with improved layout and styling (`App.tsx`, `App.css`). [[1]](diffhunk://#diff-c923327ad66f4bf11adee2222c758358dcb3e1e1d783540cab6b5aa737e48813L1-L31) [[2]](diffhunk://#diff-b1e8b727c87e1674dd7393e4d6407dd8b1e976b67e3b63aaae2476c469543947L1-R43)
* Synced dual view and theme settings between the popup and content scripts using persistent storage keys. [[1]](diffhunk://#diff-c923327ad66f4bf11adee2222c758358dcb3e1e1d783540cab6b5aa737e48813L1-L31) [[2]](diffhunk://#diff-22e78ddb617c02afbd3e8e0aecf6de92cc4a8deaf92183ead2cc4cbea9c9ff7bR13)

**Exports and Utility Updates:**

* Exported the new `DualViewToggle` component for use in other modules (`index.ts`).
* Defined and reused storage keys for dual view and theme settings in relevant files. [[1]](diffhunk://#diff-22e78ddb617c02afbd3e8e0aecf6de92cc4a8deaf92183ead2cc4cbea9c9ff7bR13) [[2]](diffhunk://#diff-a34f81fdd12cb5cbc74702bce39563119e8397271a80e50e500475fc1e2b27bbR1-R46) [[3]](diffhunk://#diff-c923327ad66f4bf11adee2222c758358dcb3e1e1d783540cab6b5aa737e48813L1-L31)

These changes collectively provide users with a more flexible and customizable interface for viewing course content.