### PR TITLE
Assign stable keys to textarea enhancers

### DIFF
--- a/packages/shared/src/components/enhancers/TextareaCounter.tsx
+++ b/packages/shared/src/components/enhancers/TextareaCounter.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useTextareaObserver } from "../../hooks";
@@ -59,8 +59,14 @@ const TextareaCounterContent: React.FC<{
  */
 export const TextareaCounter: React.FC = () => {
   const [textareas, setTextareas] = useState<HTMLTextAreaElement[]>([]);
+  const idCounterRef = useRef(0);
 
   const handleTextareaFound = useCallback((textarea: HTMLTextAreaElement) => {
+    if (!textarea.dataset.mikotoTextareaId) {
+      idCounterRef.current += 1;
+      textarea.dataset.mikotoTextareaId = `mikoto-textarea-${idCounterRef.current}`;
+    }
+
     setTextareas((prev) => {
       if (prev.includes(textarea)) return prev;
       return [...prev, textarea];
@@ -79,7 +85,7 @@ export const TextareaCounter: React.FC = () => {
     <>
       {textareas.map((textarea) => (
         <TextareaCounterContent
-          key={textarea.toString()}
+          key={textarea.dataset.mikotoTextareaId}
           textarea={textarea}
         />
       ))}

--- a/packages/shared/src/components/enhancers/TextareaCounter.tsx
+++ b/packages/shared/src/components/enhancers/TextareaCounter.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useTextareaObserver } from "../../hooks";
 import type { ExtendedHTMLTextAreaElement } from "../../types";
+import { ensureTextareaId } from "../../utils/textarea";
 import { CharacterCounter } from "../CharacterCounter";
 
 const TextareaCounterContent: React.FC<{
@@ -59,13 +60,9 @@ const TextareaCounterContent: React.FC<{
  */
 export const TextareaCounter: React.FC = () => {
   const [textareas, setTextareas] = useState<HTMLTextAreaElement[]>([]);
-  const idCounterRef = useRef(0);
 
   const handleTextareaFound = useCallback((textarea: HTMLTextAreaElement) => {
-    if (!textarea.dataset.mikotoTextareaId) {
-      idCounterRef.current += 1;
-      textarea.dataset.mikotoTextareaId = `mikoto-textarea-${idCounterRef.current}`;
-    }
+    ensureTextareaId(textarea);
 
     setTextareas((prev) => {
       if (prev.includes(textarea)) return prev;
@@ -85,7 +82,7 @@ export const TextareaCounter: React.FC = () => {
     <>
       {textareas.map((textarea) => (
         <TextareaCounterContent
-          key={textarea.dataset.mikotoTextareaId}
+          key={textarea.dataset.mikotoTextareaId ?? ensureTextareaId(textarea)}
           textarea={textarea}
         />
       ))}

--- a/packages/shared/src/components/enhancers/TextareaResizer.tsx
+++ b/packages/shared/src/components/enhancers/TextareaResizer.tsx
@@ -1,8 +1,9 @@
 import { Maximize2 } from "lucide-react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useTextareaObserver } from "../../hooks";
+import { ensureTextareaId } from "../../utils/textarea";
 import type { ExtendedHTMLTextAreaElement } from "../../types";
 
 const ResizeToggle: React.FC<{ textarea: HTMLTextAreaElement }> = ({
@@ -90,13 +91,9 @@ const TextareaResizerContent: React.FC<{
  */
 export const TextareaResizer: React.FC = () => {
   const [textareas, setTextareas] = useState<HTMLTextAreaElement[]>([]);
-  const idCounterRef = useRef(0);
 
   const handleTextareaFound = useCallback((textarea: HTMLTextAreaElement) => {
-    if (!textarea.dataset.mikotoTextareaId) {
-      idCounterRef.current += 1;
-      textarea.dataset.mikotoTextareaId = `mikoto-textarea-${idCounterRef.current}`;
-    }
+    ensureTextareaId(textarea);
 
     setTextareas((prev) => {
       if (prev.includes(textarea)) return prev;
@@ -116,7 +113,7 @@ export const TextareaResizer: React.FC = () => {
     <>
       {textareas.map((textarea) => (
         <TextareaResizerContent
-          key={textarea.dataset.mikotoTextareaId}
+          key={textarea.dataset.mikotoTextareaId ?? ensureTextareaId(textarea)}
           textarea={textarea}
         />
       ))}

--- a/packages/shared/src/components/enhancers/TextareaResizer.tsx
+++ b/packages/shared/src/components/enhancers/TextareaResizer.tsx
@@ -1,5 +1,5 @@
 import { Maximize2 } from "lucide-react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useTextareaObserver } from "../../hooks";
@@ -90,8 +90,14 @@ const TextareaResizerContent: React.FC<{
  */
 export const TextareaResizer: React.FC = () => {
   const [textareas, setTextareas] = useState<HTMLTextAreaElement[]>([]);
+  const idCounterRef = useRef(0);
 
   const handleTextareaFound = useCallback((textarea: HTMLTextAreaElement) => {
+    if (!textarea.dataset.mikotoTextareaId) {
+      idCounterRef.current += 1;
+      textarea.dataset.mikotoTextareaId = `mikoto-textarea-${idCounterRef.current}`;
+    }
+
     setTextareas((prev) => {
       if (prev.includes(textarea)) return prev;
       return [...prev, textarea];
@@ -110,7 +116,7 @@ export const TextareaResizer: React.FC = () => {
     <>
       {textareas.map((textarea) => (
         <TextareaResizerContent
-          key={textarea.toString()}
+          key={textarea.dataset.mikotoTextareaId}
           textarea={textarea}
         />
       ))}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./dom";
 export * from "./subjectExtractor";
 export * from "./text";
+export * from "./textarea";

--- a/packages/shared/src/utils/textarea.ts
+++ b/packages/shared/src/utils/textarea.ts
@@ -1,0 +1,20 @@
+let textareaIdCounter = 0;
+
+/**
+ * Ensure that the provided textarea has a stable, globally unique identifier.
+ * The identifier is stored in the dataset so multiple enhancers can reuse it.
+ */
+export const ensureTextareaId = (textarea: HTMLTextAreaElement): string => {
+  const existingId = textarea.dataset.mikotoTextareaId;
+  if (existingId) {
+    return existingId;
+  }
+
+  const id =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? `mikoto-textarea-${crypto.randomUUID()}`
+      : `mikoto-textarea-${++textareaIdCounter}`;
+
+  textarea.dataset.mikotoTextareaId = id;
+  return id;
+};


### PR DESCRIPTION
This pull request improves how the `TextareaCounter` and `TextareaResizer` components identify and manage textareas by assigning each textarea a unique, persistent ID. This change ensures better handling of dynamic textarea lists and avoids issues with React key warnings or incorrect component updates.

**Enhancements to textarea identification and management:**

* Added a unique `mikoto-textarea-<number>` ID to each textarea using a `useRef` counter, stored in the textarea's `dataset`, in both `TextareaCounter` and `TextareaResizer` components. [[1]](diffhunk://#diff-fc239e0bee84bea0db3767c427dc21ea0c0318555b64b609d1a352a3108b1791R62-R69) [[2]](diffhunk://#diff-318df5d4ef7a3b14007e01523906fee5a5f552bb26b42717eff3201b0db970aaR93-R100)
* Updated the React `key` prop for rendered textarea-related components to use the new unique ID instead of `textarea.toString()`, ensuring stable and unique keys. [[1]](diffhunk://#diff-fc239e0bee84bea0db3767c427dc21ea0c0318555b64b609d1a352a3108b1791L82-R88) [[2]](diffhunk://#diff-318df5d4ef7a3b14007e01523906fee5a5f552bb26b42717eff3201b0db970aaL113-R119)

**Code consistency:**

* Imported `useRef` in both files to support the unique ID assignment. [[1]](diffhunk://#diff-fc239e0bee84bea0db3767c427dc21ea0c0318555b64b609d1a352a3108b1791L1-R1) [[2]](diffhunk://#diff-318df5d4ef7a3b14007e01523906fee5a5f552bb26b42717eff3201b0db970aaL2-R2)…ncers