### PR TITLE
Platform-specific submit keyboard shortcut label support

### DIFF
--- a/packages/extension/entrypoints/options/App.tsx
+++ b/packages/extension/entrypoints/options/App.tsx
@@ -3,16 +3,11 @@ import {
   StorageProvider,
   type Theme,
   type KeyboardShortcutSettings,
+  getSubmitShortcutLabel,
 } from "@mikoto-moocs-sharp/shared";
 import { Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 import { storageManager } from "../utils/storage";
-
-// OS別のショートカットラベルを取得
-const getSubmitShortcutLabel = (): string => {
-  const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  return isMac ? "⌘(Command)+Enter でフォーム提出" : "Ctrl+Enter でフォーム提出";
-};
 
 function App() {
   const [theme, setTheme] = useState<Theme>("light");

--- a/packages/extension/entrypoints/options/App.tsx
+++ b/packages/extension/entrypoints/options/App.tsx
@@ -8,6 +8,12 @@ import { Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 import { storageManager } from "../utils/storage";
 
+// OS別のショートカットラベルを取得
+const getSubmitShortcutLabel = (): string => {
+  const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  return isMac ? "⌘(Command)+Enter でフォーム提出" : "Ctrl+Enter でフォーム提出";
+};
+
 function App() {
   const [theme, setTheme] = useState<Theme>("light");
   const [shortcuts, setShortcuts] = useState<KeyboardShortcutSettings>({
@@ -15,6 +21,7 @@ function App() {
     numberKeyShortcut: false,
     arrowKeyShortcut: false,
   });
+  const submitShortcutLabel = getSubmitShortcutLabel();
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -103,7 +110,7 @@ function App() {
                 onChange={() => handleShortcutToggle("submitShortcut")}
                 style={{ width: "18px", height: "18px", cursor: "pointer" }}
               />
-              <span>Ctrl/Cmd+Enter でフォーム提出</span>
+              <span>{submitShortcutLabel}</span>
             </label>
             <label
               style={{

--- a/packages/extension/entrypoints/popup/App.tsx
+++ b/packages/extension/entrypoints/popup/App.tsx
@@ -6,6 +6,12 @@ import type {
 } from "@mikoto-moocs-sharp/shared";
 import { storageManager } from "../utils/storage";
 
+// OS別のショートカットラベルを取得
+const getSubmitShortcutLabel = (): string => {
+  const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  return isMac ? "⌘(Command)+Enter でフォーム提出" : "Ctrl+Enter でフォーム提出";
+};
+
 function App() {
   const [dualViewEnabled, setDualViewEnabled] = useState(false);
   const [theme, setTheme] = useState<Theme>("light");
@@ -14,6 +20,7 @@ function App() {
     numberKeyShortcut: false,
     arrowKeyShortcut: false,
   });
+  const submitShortcutLabel = getSubmitShortcutLabel();
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -68,9 +75,7 @@ function App() {
           />
         </div>
         <div className="setting-item">
-          <label htmlFor="submit-shortcut-toggle">
-            Ctrl/Cmd+Enter でフォーム提出
-          </label>
+          <label htmlFor="submit-shortcut-toggle">{submitShortcutLabel}</label>
           <input
             id="submit-shortcut-toggle"
             type="checkbox"

--- a/packages/extension/entrypoints/popup/App.tsx
+++ b/packages/extension/entrypoints/popup/App.tsx
@@ -1,16 +1,11 @@
 import { useEffect, useState } from "react";
 import "./App.css";
-import type {
-  Theme,
-  KeyboardShortcutSettings,
+import {
+  type Theme,
+  type KeyboardShortcutSettings,
+  getSubmitShortcutLabel,
 } from "@mikoto-moocs-sharp/shared";
 import { storageManager } from "../utils/storage";
-
-// OS別のショートカットラベルを取得
-const getSubmitShortcutLabel = (): string => {
-  const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  return isMac ? "⌘(Command)+Enter でフォーム提出" : "Ctrl+Enter でフォーム提出";
-};
 
 function App() {
   const [dualViewEnabled, setDualViewEnabled] = useState(false);

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "baseUrl": ".",
+    "paths": {
+      "@mikoto-moocs-sharp/shared": ["../shared/src/index.ts"],
+      "@mikoto-moocs-sharp/shared/*": ["../shared/src/*"]
+    }
   },
   "include": [".wxt/**/*", "entrypoints/**/*"]
 }

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
         ),
         "@mikoto-moocs-sharp/shared": path.resolve(
           __dirname,
-          "../shared/src/index.ts",
+          "../shared/src",
         ),
       },
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./*": "./src/*"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,8 +12,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*"
+    ".": "./src/index.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,6 @@ export * from "./hooks";
 export * from "./storage";
 export * from "./types";
 export * from "./utils";
+
+// Explicitly re-export platform utilities for better TypeScript resolution
+export { isMacPlatform, getSubmitShortcutLabel } from "./utils/platform";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,5 +5,4 @@ export * from "./constants";
 export * from "./hooks";
 export * from "./storage";
 export * from "./types";
-export * from "./utils/dom";
-export * from "./utils/text";
+export * from "./utils";

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./dom";
+export * from "./platform";
 export * from "./subjectExtractor";
 export * from "./text";
 export * from "./textarea";

--- a/packages/shared/src/utils/platform.ts
+++ b/packages/shared/src/utils/platform.ts
@@ -1,0 +1,25 @@
+/**
+ * プラットフォーム検出とキーボードショートカット関連のユーティリティ
+ */
+
+/**
+ * macOS系のプラットフォームかどうかを判定
+ * @returns macOS、iPhone、iPad、iPodの場合true
+ */
+export const isMacPlatform = (): boolean => {
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+};
+
+/**
+ * Ctrl/Cmd+Enterのショートカットラベルを取得
+ * @returns OS別のショートカットラベル
+ */
+export const getSubmitShortcutLabel = (): string => {
+  const isMac = isMacPlatform();
+
+  if (isMac) {
+    return "⌘(Command)+Enter でフォーム提出";
+  }
+
+  return "Ctrl+Enter でフォーム提出";
+};


### PR DESCRIPTION
This pull request introduces platform-aware keyboard shortcut labels for form submission in both the options and popup UIs of the extension, ensuring users see the correct shortcut based on their operating system. It also refactors shared utility exports for improved TypeScript resolution and updates configuration for module path mapping.

**Platform-specific shortcut label support:**

* Added `isMacPlatform` and `getSubmitShortcutLabel` utilities to `packages/shared/src/utils/platform.ts` to detect the user's OS and return the appropriate shortcut label for form submission.
* Updated both `App.tsx` files in `entrypoints/options` and `entrypoints/popup` to use `getSubmitShortcutLabel`, replacing hardcoded shortcut text with dynamic labels. [[1]](diffhunk://#diff-eb87fdb6e41141c9de40ca12ae0a5f35a4fbed705ff5ad985f5c06873862057eR6) [[2]](diffhunk://#diff-eb87fdb6e41141c9de40ca12ae0a5f35a4fbed705ff5ad985f5c06873862057eR19) [[3]](diffhunk://#diff-eb87fdb6e41141c9de40ca12ae0a5f35a4fbed705ff5ad985f5c06873862057eL106-R108) [[4]](diffhunk://#diff-2b28fcb0328295fdf34f7f95dbef3cad813acae7b19f0c02ac539fee102bc6eaL3-R6) [[5]](diffhunk://#diff-2b28fcb0328295fdf34f7f95dbef3cad813acae7b19f0c02ac539fee102bc6eaR18) [[6]](diffhunk://#diff-2b28fcb0328295fdf34f7f95dbef3cad813acae7b19f0c02ac539fee102bc6eaL71-R73)

**Shared utility module improvements:**

* Refactored exports in `packages/shared/src/index.ts` to explicitly re-export platform utilities for better TypeScript resolution and consolidated utility exports. [[1]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaL8-R11) [[2]](diffhunk://#diff-35d645f5c8f550d60b305ffb1713b460aca0ecac182b18acefc8c6a47282e1bcR2)

**Configuration updates:**

* Updated `tsconfig.json` and `wxt.config.ts` to improve module path mapping for `@mikoto-moocs-sharp/shared`, ensuring correct import resolution across packages. [[1]](diffhunk://#diff-5458d63c05c33e368d8b26ba5f6867490a575af6a67f19e7bd1c18a91477d193L6-R11) [[2]](diffhunk://#diff-366293d086424634bae212369b6829a88c1b6123a04afed08811d27fe5b1689fL23-R23)