### PR TITLE
fix(userscript): SCSSをCSSに変換

### DIFF
--- a/packages/userscript-base/src/main.tsx
+++ b/packages/userscript-base/src/main.tsx
@@ -1,4 +1,4 @@
-import contentCssContent from "@mikoto-moocs-sharp/shared/styles/content.scss?raw";
+import contentStyle from "@mikoto-moocs-sharp/shared/styles/content.scss?inline";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { GM_registerMenuCommand } from "$";
@@ -23,7 +23,7 @@ export function initializeMikoto() {
       // 静的CSSを手動で注入
       const style = document.createElement("style");
       style.setAttribute("data-mikoto-styles", "true");
-      style.textContent = contentCssContent;
+      style.textContent = contentStyle;
       document.head.appendChild(style);
 
       // アプリケーションをマウントするコンテナを作成

--- a/packages/userscript-base/src/mainLite.tsx
+++ b/packages/userscript-base/src/mainLite.tsx
@@ -1,4 +1,4 @@
-import contentCssContent from "@mikoto-moocs-sharp/shared/styles/content.scss?raw";
+import contentStyle from "@mikoto-moocs-sharp/shared/styles/content.scss?inline";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { GM_registerMenuCommand } from "$";
@@ -23,7 +23,7 @@ export function initializeMikotoLite() {
       // 静的CSSを手動で注入
       const style = document.createElement("style");
       style.setAttribute("data-mikoto-styles", "true");
-      style.textContent = contentCssContent;
+      style.textContent = contentStyle;
       document.head.appendChild(style);
 
       // アプリケーションをマウントするコンテナを作成

--- a/packages/userscript-base/src/utils/injectContentStyle.ts
+++ b/packages/userscript-base/src/utils/injectContentStyle.ts
@@ -1,0 +1,27 @@
+import contentStyle from "@mikoto-moocs-sharp/shared/styles/content.scss?style";
+
+let injected = false;
+
+/**
+ * Ensure Mikoto base styles are available on the page.
+ */
+export function ensureContentStyleInjected() {
+  if (injected) {
+    return;
+  }
+
+  const nextStyle = contentStyle.cloneNode(true) as HTMLStyleElement;
+  nextStyle.setAttribute("data-mikoto-styles", "true");
+
+  const previousStyle = document.head.querySelector<HTMLStyleElement>(
+    'style[data-mikoto-styles="true"]',
+  );
+
+  if (previousStyle) {
+    previousStyle.replaceWith(nextStyle);
+  } else {
+    document.head.append(nextStyle);
+  }
+
+  injected = true;
+}


### PR DESCRIPTION
#64

This pull request updates how the base CSS styles are imported and injected in the userscript base package. It switches from using the `?raw` loader to the `?inline` and `?style` loaders for SCSS files, and introduces a new utility to ensure styles are injected only once and can be updated efficiently.

**CSS Import and Injection Improvements:**

* Changed SCSS imports in `main.tsx` and `mainLite.tsx` from using the `?raw` loader to the `?inline` loader, ensuring the styles are injected as expected for userscripts. [[1]](diffhunk://#diff-70678325057ca86a7f7f4dea0a492d3c3167af679fb281f59622b64b97b0fd33L1-R1) [[2]](diffhunk://#diff-2428d2f9e1c8d37b8b6b31602901ca480ce40a83a40eed1f828a0a1208d9a31fL1-R1)
* Updated style injection in both `initializeMikoto` and `initializeMikotoLite` to use the new `contentStyle` variable, reflecting the loader change. [[1]](diffhunk://#diff-70678325057ca86a7f7f4dea0a492d3c3167af679fb281f59622b64b97b0fd33L26-R26) [[2]](diffhunk://#diff-2428d2f9e1c8d37b8b6b31602901ca480ce40a83a40eed1f828a0a1208d9a31fL26-R26)
* Added a new utility function `ensureContentStyleInjected` in `injectContentStyle.ts` that uses the `?style` loader to inject the base styles only once, replacing any previous style if necessary, and preventing duplicate injections.