### PR TITLE
chore(dependabot): support pnpm single workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  # Root workspace
+  # pnpm workspace - single lockfile at root
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -9,90 +9,10 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     labels:
       - "dependencies"
       - "automated"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # Shared package
-  - package-ecosystem: "npm"
-    directory: "/packages/shared"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "shared"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # Extension package
-  - package-ecosystem: "npm"
-    directory: "/packages/extension"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "extension"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # Userscript base package
-  - package-ecosystem: "npm"
-    directory: "/packages/userscript-base"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "userscript"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # Userscript lite package
-  - package-ecosystem: "npm"
-    directory: "/packages/userscript-lite"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "userscript"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # Userscript pro package
-  - package-ecosystem: "npm"
-    directory: "/packages/userscript-pro"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "userscript"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
@@ -105,7 +25,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 50
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
This pull request streamlines the Dependabot configuration by consolidating npm update management to the root directory and increasing the open pull request limit. The changes simplify dependency update workflows and reduce configuration duplication.

**Dependabot configuration simplification:**

* Removed separate npm update configurations for individual package directories (`/packages/shared`, `/packages/extension`, `/packages/userscript-base`, `/packages/userscript-lite`, `/packages/userscript-pro`) in favor of a single root-level configuration, leveraging the pnpm workspace with a single lockfile.
* Increased the `open-pull-requests-limit` for both npm and GitHub Actions updates at the root level to 50, allowing more simultaneous dependency update PRs. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L4-L99) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L108-R28)