### PR TITLE
chore: サークル名の変更に伴いソフトウェア内の名称を更新

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025 INIAD-mdx
+Copyright (c) 2025 情報技術メディア研究会 (GeeKEN)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Mikotoは、MOOCsをより便利に利用するためのツールです。ブラ
 
 ## 機能
 
-[プロジェクトボード](https://github.com/orgs/iniad-mdx/projects/2)
+[プロジェクトボード](https://github.com/orgs/geeken-iniad/projects/2)
 
 - [x] ⚠️ 出席、課題があるタブを色付けして目立たせる
 - [ ] 🕰️ 今・次の授業コマ情報の表示

--- a/packages/userscript-lite/vite.config.ts
+++ b/packages/userscript-lite/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         description: "MOOCsをより便利に (基本機能版)",
         author: "INIAD MDX",
         icon: "https://moocs.iniad.org/favicon.ico",
-        namespace: "https://github.com/iniad-mdx",
+        namespace: "https://github.com/geeken-iniad",
         match: ["https://moocs.iniad.org/*"],
         "run-at": "document-idle",
         grant: [

--- a/packages/userscript-pro/vite.config.ts
+++ b/packages/userscript-pro/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         description: "MOOCsをより便利に (全機能版)",
         author: "INIAD MDX",
         icon: "https://moocs.iniad.org/favicon.ico",
-        namespace: "https://github.com/iniad-mdx",
+        namespace: "https://github.com/geeken-iniad",
         match: ["https://moocs.iniad.org/*"],
         "run-at": "document-idle",
         grant: [


### PR DESCRIPTION
This pull request updates project references and copyright information to reflect a change in organizational ownership from "INIAD-mdx" to "情報技術メディア研究会 (GeeKEN)" and updates related URLs and namespaces throughout the project.

Ownership and attribution updates:

* Changed the copyright holder in the `LICENSE` file from "INIAD-mdx" to "情報技術メディア研究会 (GeeKEN)".
* Updated the project board link in `README.md` to use the new GitHub organization (`geeken-iniad`).

Namespace and URL updates:

* Changed the `namespace` field in `packages/userscript-lite/vite.config.ts` from the old GitHub organization to the new one.
* Changed the `namespace` field in `packages/userscript-pro/vite.config.ts` from the old GitHub organization to the new one.